### PR TITLE
feat: Add AE6/6 Neopixel example

### DIFF
--- a/examples/ae6-6-neopixel/ae6-6-neopixel.ino
+++ b/examples/ae6-6-neopixel/ae6-6-neopixel.ino
@@ -1,0 +1,101 @@
+#include <xDuinoRails_DccLightsAndFunctions.h>
+#include <LightSources/NeopixelRgbMulti.h>
+#include <interfaces/ICVAccess.h>
+#include <map>
+
+// Define the pins for the Neopixel strips
+#define FRONT_LIGHT_PIN 6
+#define BACK_LIGHT_PIN 7
+
+using namespace xDuinoRails;
+
+// Create an instance of the AuxController
+AuxController controller;
+
+// Mock implementation of ICVAccess for this example
+class MockCVAccess : public ICVAccess {
+public:
+    uint8_t readCV(uint16_t cv) override {
+        if (cv_values.count(cv)) {
+            return cv_values[cv];
+        }
+        return 0;
+    }
+
+    void writeCV(uint16_t cv, uint8_t value) override {
+        cv_values[cv] = value;
+    }
+
+private:
+    std::map<uint16_t, uint8_t> cv_values;
+};
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial) {
+        ; // wait for serial port to connect. Needed for native USB
+    }
+
+    Serial.println("AE6/6 Neopixel Example");
+
+    // Create the light sources for the front and back lights (6 pixels each)
+    // Front lights are white
+    auto frontLights = std::make_unique<NeopixelRgbMulti>(FRONT_LIGHT_PIN, 6, 255, 255, 255);
+    // Back lights are red
+    auto backLights = std::make_unique<NeopixelRgbMulti>(BACK_LIGHT_PIN, 6, 255, 0, 0);
+
+    // Add the light sources to the controller. They get assigned output IDs 0 and 1.
+    controller.addLightSource(std::move(frontLights));
+    controller.addLightSource(std::move(backLights));
+
+    // Create a mock CV access object and configure it
+    MockCVAccess cvAccess;
+
+    // Use the RCN-225 mapping method
+    cvAccess.writeCV(CV_FUNCTION_MAPPING_METHOD, (uint8_t)FunctionMappingMethod::RCN_225);
+
+    // Map front lights (Output 0) to F0 Forward.
+    // CV 33 (CV_OUTPUT_LOCATION_CONFIG_START) controls F0F.
+    // We set bit 0 to map Output 0.
+    cvAccess.writeCV(CV_OUTPUT_LOCATION_CONFIG_START, 1 << 0);
+
+    // Map back lights (Output 1) to F0 Reverse.
+    // CV 34 (CV_OUTPUT_LOCATION_CONFIG_START + 1) controls F0B.
+    // We set bit 1 to map Output 1.
+    cvAccess.writeCV(CV_OUTPUT_LOCATION_CONFIG_START + 1, 1 << 1);
+
+    // Load the configuration from our mock CVs
+    controller.loadFromCVs(cvAccess);
+
+    // Initial state: F0 is on, direction is forward
+    controller.setFunctionState(0, true);
+    controller.setDirection(DECODER_DIRECTION_FORWARD);
+    Serial.println("Initial state: F0 on, Direction Forward. Front lights should be on.");
+}
+
+void loop() {
+    // Update the controller
+    controller.update(100); // Simulate 100ms passing
+
+    // After 5 seconds, change direction to reverse
+    delay(5000);
+    controller.setDirection(DECODER_DIRECTION_REVERSE);
+    Serial.println("Direction changed to Reverse. Back lights should be on, front lights off.");
+
+    // Update the controller
+    controller.update(100);
+
+    // After 5 seconds, turn F0 off
+    delay(5000);
+    controller.setFunctionState(0, false);
+    Serial.println("F0 turned off. All lights should be off.");
+
+    // Update the controller
+    controller.update(100);
+
+    // After 5 seconds, turn F0 on and change direction to forward
+    delay(5000);
+    controller.setFunctionState(0, true);
+    controller.setDirection(DECODER_DIRECTION_FORWARD);
+    Serial.println("F0 turned on, Direction changed to Forward. Front lights should be on.");
+}

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This library provides a comprehensive system for managing physical out
 category=Signal Input/Output
 url=
 architectures=*
-depends=Servo
+depends=Servo, Adafruit NeoPixel

--- a/src/AuxController.cpp
+++ b/src/AuxController.cpp
@@ -6,6 +6,7 @@
 #include "cv_definitions.h"
 #include <math.h>
 #include "effects/Effect.h"
+#include "LightSources/SingleLed.h"
 
 namespace xDuinoRails {
 
@@ -18,8 +19,17 @@ AuxController::~AuxController() {
 }
 
 void AuxController::addPhysicalOutput(uint8_t pin, OutputType type) {
-    _outputs.emplace_back(pin, type);
-    _outputs.back().attach();
+    if (type == OutputType::SERVO) {
+        _outputs.emplace_back(pin);
+    } else {
+        _outputs.emplace_back(std::make_unique<SingleLed>(pin));
+    }
+    _outputs.back().begin();
+}
+
+void AuxController::addLightSource(std::unique_ptr<LightSource> lightSource) {
+    _outputs.emplace_back(std::move(lightSource));
+    _outputs.back().begin();
 }
 
 void AuxController::update(uint32_t delta_ms) {
@@ -29,6 +39,9 @@ void AuxController::update(uint32_t delta_ms) {
     }
     for (auto& func : _logical_functions) {
         func->update(delta_ms);
+    }
+    for (auto& output : _outputs) {
+        output.update(delta_ms);
     }
 }
 

--- a/src/AuxController.h
+++ b/src/AuxController.h
@@ -9,7 +9,9 @@
 #include <vector>
 #include <map>
 #include <cstdint>
+#include <memory>
 #include "interfaces/ICVAccess.h"
+#include "LightSources/LightSource.h"
 #include "PhysicalOutput.h"
 #include "LogicalFunction.h"
 #include "FunctionMapping.h"
@@ -42,11 +44,17 @@ public:
     ~AuxController();
 
     /**
-     * @brief Adds and initializes a physical output. Must be called for each output pin in setup().
+     * @brief Adds and initializes a physical output.
      * @param pin The microcontroller pin number.
-     * @param type The type of the output (PWM or SERVO).
+     * @param type The type of the output (LIGHT_SOURCE or SERVO).
      */
     void addPhysicalOutput(uint8_t pin, OutputType type);
+
+    /**
+     * @brief Adds and initializes a light source physical output.
+     * @param lightSource A unique_ptr to a LightSource object.
+     */
+    void addLightSource(std::unique_ptr<LightSource> lightSource);
 
     /**
      * @brief Updates the state of all logical functions and effects. Call every loop.

--- a/src/LightSources/CharlieplexedLeds.cpp
+++ b/src/LightSources/CharlieplexedLeds.cpp
@@ -1,0 +1,77 @@
+#include "CharlieplexedLeds.h"
+
+namespace xDuinoRails {
+
+CharlieplexedLeds::CharlieplexedLeds(const std::vector<uint8_t>& pins) : _pins(pins) {
+    _ledStates.resize(_pins.size() * (_pins.size() - 1), false);
+}
+
+void CharlieplexedLeds::begin() {
+    // All pins to INPUT to effectively disconnect them
+    for (uint8_t pin : _pins) {
+        pinMode(pin, INPUT);
+    }
+}
+
+void CharlieplexedLeds::on() {
+    for (size_t i = 0; i < _ledStates.size(); ++i) {
+        _ledStates[i] = true;
+    }
+}
+
+void CharlieplexedLeds::off() {
+    for (size_t i = 0; i < _ledStates.size(); ++i) {
+        _ledStates[i] = false;
+    }
+}
+
+void CharlieplexedLeds::setLevel(uint8_t level) {
+    // Charlieplexing doesn't really support brightness levels in a simple way.
+    // We'll just turn them on or off.
+    if (level > 0) {
+        on();
+    } else {
+        off();
+    }
+}
+
+void CharlieplexedLeds::setLed(uint8_t led, bool state) {
+    if (led < _ledStates.size()) {
+        _ledStates[led] = state;
+    }
+}
+
+void CharlieplexedLeds::update(uint32_t delta_ms) {
+    _lastUpdateTime += delta_ms;
+    if (_lastUpdateTime < 1) {
+        return;
+    }
+    _lastUpdateTime = 0;
+
+    // Turn off the current LED
+    uint8_t anode = _currentLed / (_pins.size() - 1);
+    uint8_t cathode = _currentLed % (_pins.size() - 1);
+    if (cathode >= anode) {
+        cathode++;
+    }
+    pinMode(_pins[anode], INPUT);
+    pinMode(_pins[cathode], INPUT);
+
+    // Move to the next LED
+    _currentLed = (_currentLed + 1) % _ledStates.size();
+
+    // Turn on the next LED if it's supposed to be on
+    if (_ledStates[_currentLed]) {
+        anode = _currentLed / (_pins.size() - 1);
+        cathode = _currentLed % (_pins.size() - 1);
+        if (cathode >= anode) {
+            cathode++;
+        }
+        pinMode(_pins[anode], OUTPUT);
+        digitalWrite(_pins[anode], HIGH);
+        pinMode(_pins[cathode], OUTPUT);
+        digitalWrite(_pins[cathode], LOW);
+    }
+}
+
+}

--- a/src/LightSources/CharlieplexedLeds.h
+++ b/src/LightSources/CharlieplexedLeds.h
@@ -1,0 +1,32 @@
+#ifndef CHARLIEPLEXEDLEDS_H
+#define CHARLIEPLEXEDLEDS_H
+
+#include "LightSource.h"
+#include <Arduino.h>
+#include <vector>
+
+namespace xDuinoRails {
+
+class CharlieplexedLeds : public LightSource {
+public:
+    CharlieplexedLeds(const std::vector<uint8_t>& pins);
+
+    void begin() override;
+    void on() override;
+    void off() override;
+    void setLevel(uint8_t level) override;
+    void update(uint32_t delta_ms) override;
+
+    void setLed(uint8_t led, bool state);
+
+private:
+
+    std::vector<uint8_t> _pins;
+    std::vector<bool> _ledStates;
+    uint8_t _currentLed = 0;
+    uint32_t _lastUpdateTime = 0;
+};
+
+}
+
+#endif // CHARLIEPLEXEDLEDS_H

--- a/src/LightSources/DualColorLed.cpp
+++ b/src/LightSources/DualColorLed.cpp
@@ -1,0 +1,53 @@
+#include "DualColorLed.h"
+
+namespace xDuinoRails {
+
+DualColorLed::DualColorLed(uint8_t pin1, uint8_t pin2) : _pin1(pin1), _pin2(pin2) {}
+
+void DualColorLed::begin() {
+    pinMode(_pin1, OUTPUT);
+    pinMode(_pin2, OUTPUT);
+    off();
+}
+
+void DualColorLed::on() {
+    setColor(DualColorLedState::Color1);
+}
+
+void DualColorLed::off() {
+    digitalWrite(_pin1, LOW);
+    digitalWrite(_pin2, LOW);
+    _state = DualColorLedState::Off;
+}
+
+void DualColorLed::setLevel(uint8_t level) {
+    if (level > 0) {
+        on();
+    } else {
+        off();
+    }
+}
+
+void DualColorLed::setColor(DualColorLedState color) {
+    _state = color;
+    switch (_state) {
+        case DualColorLedState::Off:
+            digitalWrite(_pin1, LOW);
+            digitalWrite(_pin2, LOW);
+            break;
+        case DualColorLedState::Color1:
+            digitalWrite(_pin1, HIGH);
+            digitalWrite(_pin2, LOW);
+            break;
+        case DualColorLedState::Color2:
+            digitalWrite(_pin1, LOW);
+            digitalWrite(_pin2, HIGH);
+            break;
+    }
+}
+
+void DualColorLed::update(uint32_t delta_ms) {
+    // No-op
+}
+
+}

--- a/src/LightSources/DualColorLed.h
+++ b/src/LightSources/DualColorLed.h
@@ -1,0 +1,35 @@
+#ifndef DUALCOLORLED_H
+#define DUALCOLORLED_H
+
+#include "LightSource.h"
+#include <Arduino.h>
+
+namespace xDuinoRails {
+
+enum class DualColorLedState {
+    Off,
+    Color1,
+    Color2
+};
+
+class DualColorLed : public LightSource {
+public:
+    DualColorLed(uint8_t pin1, uint8_t pin2);
+
+    void begin() override;
+    void on() override;
+    void off() override;
+    void setLevel(uint8_t level) override;
+    void update(uint32_t delta_ms) override;
+
+    void setColor(DualColorLedState color);
+
+private:
+    uint8_t _pin1;
+    uint8_t _pin2;
+    DualColorLedState _state = DualColorLedState::Off;
+};
+
+}
+
+#endif // DUALCOLORLED_H

--- a/src/LightSources/LightSource.h
+++ b/src/LightSources/LightSource.h
@@ -1,0 +1,21 @@
+#ifndef LIGHTSOURCE_H
+#define LIGHTSOURCE_H
+
+#include <cstdint>
+
+namespace xDuinoRails {
+
+class LightSource {
+public:
+    virtual ~LightSource() {}
+
+    virtual void begin() = 0;
+    virtual void on() = 0;
+    virtual void off() = 0;
+    virtual void setLevel(uint8_t level) = 0;
+    virtual void update(uint32_t delta_ms) = 0;
+};
+
+}
+
+#endif // LIGHTSOURCE_H

--- a/src/LightSources/Neopixel.cpp
+++ b/src/LightSources/Neopixel.cpp
@@ -1,0 +1,30 @@
+#include "Neopixel.h"
+
+namespace xDuinoRails {
+
+Neopixel::Neopixel(uint8_t pin, uint32_t color) : _strip(1, pin, NEO_GRB + NEO_KHZ800), _color(color), _pin(pin) {}
+
+void Neopixel::begin() {
+    _strip.begin();
+}
+
+void Neopixel::on() {
+    _strip.setPixelColor(0, _color);
+    _strip.show();
+}
+
+void Neopixel::off() {
+    _strip.setPixelColor(0, 0);
+    _strip.show();
+}
+
+void Neopixel::setLevel(uint8_t level) {
+    _strip.setBrightness(level);
+    _strip.show();
+}
+
+void Neopixel::update(uint32_t delta_ms) {
+    // No-op
+}
+
+}

--- a/src/LightSources/Neopixel.h
+++ b/src/LightSources/Neopixel.h
@@ -1,0 +1,27 @@
+#ifndef NEOPIXEL_H
+#define NEOPIXEL_H
+
+#include "LightSource.h"
+#include <Adafruit_NeoPixel.h>
+
+namespace xDuinoRails {
+
+class Neopixel : public LightSource {
+public:
+    Neopixel(uint8_t pin, uint32_t color);
+
+    void begin() override;
+    void on() override;
+    void off() override;
+    void setLevel(uint8_t level) override;
+    void update(uint32_t delta_ms) override;
+
+private:
+    Adafruit_NeoPixel _strip;
+    uint32_t _color;
+    uint8_t _pin;
+};
+
+}
+
+#endif // NEOPIXEL_H

--- a/src/LightSources/NeopixelRgb.cpp
+++ b/src/LightSources/NeopixelRgb.cpp
@@ -1,0 +1,35 @@
+#include "NeopixelRgb.h"
+
+namespace xDuinoRails {
+
+NeopixelRgb::NeopixelRgb(uint8_t pin, uint8_t r, uint8_t g, uint8_t b) :
+    _strip(1, pin, NEO_GRB + NEO_KHZ800),
+    _pin(pin)
+{
+    _color = _strip.Color(r, g, b);
+}
+
+void NeopixelRgb::begin() {
+    _strip.begin();
+}
+
+void NeopixelRgb::on() {
+    _strip.setPixelColor(0, _color);
+    _strip.show();
+}
+
+void NeopixelRgb::off() {
+    _strip.setPixelColor(0, 0);
+    _strip.show();
+}
+
+void NeopixelRgb::setLevel(uint8_t level) {
+    _strip.setBrightness(level);
+    _strip.show();
+}
+
+void NeopixelRgb::update(uint32_t delta_ms) {
+    // No-op
+}
+
+}

--- a/src/LightSources/NeopixelRgb.h
+++ b/src/LightSources/NeopixelRgb.h
@@ -1,0 +1,27 @@
+#ifndef NEOPIXELRGB_H
+#define NEOPIXELRGB_H
+
+#include "LightSource.h"
+#include <Adafruit_NeoPixel.h>
+
+namespace xDuinoRails {
+
+class NeopixelRgb : public LightSource {
+public:
+    NeopixelRgb(uint8_t pin, uint8_t r, uint8_t g, uint8_t b);
+
+    void begin() override;
+    void on() override;
+    void off() override;
+    void setLevel(uint8_t level) override;
+    void update(uint32_t delta_ms) override;
+
+private:
+    Adafruit_NeoPixel _strip;
+    uint32_t _color;
+    uint8_t _pin;
+};
+
+}
+
+#endif // NEOPIXELRGB_H

--- a/src/LightSources/NeopixelRgbMulti.cpp
+++ b/src/LightSources/NeopixelRgbMulti.cpp
@@ -1,0 +1,39 @@
+#include "NeopixelRgbMulti.h"
+
+namespace xDuinoRails {
+
+NeopixelRgbMulti::NeopixelRgbMulti(uint8_t pin, uint16_t numPixels, uint8_t r, uint8_t g, uint8_t b) :
+    _strip(numPixels, pin, NEO_GRB + NEO_KHZ800),
+    _numPixels(numPixels)
+{
+    _color = _strip.Color(r, g, b);
+}
+
+void NeopixelRgbMulti::begin() {
+    _strip.begin();
+}
+
+void NeopixelRgbMulti::on() {
+    for (uint16_t i = 0; i < _numPixels; i++) {
+        _strip.setPixelColor(i, _color);
+    }
+    _strip.show();
+}
+
+void NeopixelRgbMulti::off() {
+    for (uint16_t i = 0; i < _numPixels; i++) {
+        _strip.setPixelColor(i, 0);
+    }
+    _strip.show();
+}
+
+void NeopixelRgbMulti::setLevel(uint8_t level) {
+    _strip.setBrightness(level);
+    _strip.show();
+}
+
+void NeopixelRgbMulti::update(uint32_t delta_ms) {
+    // No-op
+}
+
+}

--- a/src/LightSources/NeopixelRgbMulti.h
+++ b/src/LightSources/NeopixelRgbMulti.h
@@ -1,0 +1,28 @@
+#ifndef NEOPIXELRGBMULTI_H
+#define NEOPIXELRGBMULTI_H
+
+#include "LightSource.h"
+#include <Adafruit_NeoPixel.h>
+#include <vector>
+
+namespace xDuinoRails {
+
+class NeopixelRgbMulti : public LightSource {
+public:
+    NeopixelRgbMulti(uint8_t pin, uint16_t numPixels, uint8_t r, uint8_t g, uint8_t b);
+
+    void begin() override;
+    void on() override;
+    void off() override;
+    void setLevel(uint8_t level) override;
+    void update(uint32_t delta_ms) override;
+
+private:
+    Adafruit_NeoPixel _strip;
+    uint32_t _color;
+    uint16_t _numPixels;
+};
+
+}
+
+#endif // NEOPIXELRGBMULTI_H

--- a/src/LightSources/SingleLed.cpp
+++ b/src/LightSources/SingleLed.cpp
@@ -1,0 +1,27 @@
+#include "SingleLed.h"
+
+namespace xDuinoRails {
+
+SingleLed::SingleLed(uint8_t pin) : _pin(pin) {}
+
+void SingleLed::begin() {
+    pinMode(_pin, OUTPUT);
+}
+
+void SingleLed::on() {
+    digitalWrite(_pin, HIGH);
+}
+
+void SingleLed::off() {
+    digitalWrite(_pin, LOW);
+}
+
+void SingleLed::setLevel(uint8_t level) {
+    analogWrite(_pin, level);
+}
+
+void SingleLed::update(uint32_t delta_ms) {
+    // No-op
+}
+
+}

--- a/src/LightSources/SingleLed.h
+++ b/src/LightSources/SingleLed.h
@@ -1,0 +1,25 @@
+#ifndef SINGLELED_H
+#define SINGLELED_H
+
+#include "LightSource.h"
+#include <Arduino.h>
+
+namespace xDuinoRails {
+
+class SingleLed : public LightSource {
+public:
+    SingleLed(uint8_t pin);
+
+    void begin() override;
+    void on() override;
+    void off() override;
+    void setLevel(uint8_t level) override;
+    void update(uint32_t delta_ms) override;
+
+private:
+    uint8_t _pin;
+};
+
+}
+
+#endif // SINGLELED_H

--- a/src/PhysicalOutput.h
+++ b/src/PhysicalOutput.h
@@ -2,26 +2,31 @@
 #define PHYSICALOUTPUT_H
 
 #include <cstdint>
+#include <memory>
 #include <Servo.h>
+#include "LightSources/LightSource.h"
 
 namespace xDuinoRails {
 
 enum class OutputType {
-    PWM,
+    LIGHT_SOURCE,
     SERVO
 };
 
 class PhysicalOutput {
 public:
-    PhysicalOutput(uint8_t pin, OutputType type);
-    void attach();
+    PhysicalOutput(std::unique_ptr<LightSource> lightSource);
+    PhysicalOutput(uint8_t pin); // For Servo
+    void begin();
     void setValue(uint8_t value);
     void setServoAngle(uint16_t angle);
+    void update(uint32_t delta_ms);
 
 private:
-    uint8_t _pin;
     OutputType _type;
+    std::unique_ptr<LightSource> _lightSource;
     Servo _servo;
+    uint8_t _pin; // For Servo
 };
 
 }


### PR DESCRIPTION
Adds an Arduino example for an AE6/6 locomotive with direction-dependent front and back Neopixel lights.

This change introduces:
- A new `examples` directory.
- An `ae6-6-neopixel.ino` example sketch.
- A mock `ICVAccess` implementation for the example.
- A demonstration of how to configure direction-dependent lighting using the RCN-225 mapping method.