### PR TITLE
feat: Add specialized light source for Ae 6/6 tail lights

### DIFF
--- a/examples/ae6-6-neopixel/ae6-6-neopixel.ino
+++ b/examples/ae6-6-neopixel/ae6-6-neopixel.ino
@@ -1,5 +1,6 @@
 #include <xDuinoRails_DccLightsAndFunctions.h>
 #include <LightSources/NeopixelRgbMulti.h>
+#include <LightSources/NeopixelRgbMultiSwissAe66.h>
 #include <interfaces/ICVAccess.h>
 #include <map>
 
@@ -42,7 +43,7 @@ void setup() {
     // Front lights are white
     auto frontLights = std::make_unique<NeopixelRgbMulti>(FRONT_LIGHT_PIN, 6, 255, 255, 255);
     // Back lights are red
-    auto backLights = std::make_unique<NeopixelRgbMulti>(BACK_LIGHT_PIN, 6, 255, 0, 0);
+    auto backLights = std::make_unique<NeopixelRgbMultiSwissAe66>(BACK_LIGHT_PIN, 3, 255, 0, 0);
 
     // Add the light sources to the controller. They get assigned output IDs 0 and 1.
     controller.addLightSource(std::move(frontLights));

--- a/src/LightSources/NeopixelRgbMultiSwissAe66.cpp
+++ b/src/LightSources/NeopixelRgbMultiSwissAe66.cpp
@@ -1,0 +1,46 @@
+#include "NeopixelRgbMultiSwissAe66.h"
+
+namespace xDuinoRails {
+
+NeopixelRgbMultiSwissAe66::NeopixelRgbMultiSwissAe66(uint8_t pin, uint16_t numPixels, uint8_t r, uint8_t g, uint8_t b) :
+    _strip(numPixels, pin, NEO_GRB + NEO_KHZ800),
+    _numPixels(numPixels)
+{
+    _color = _strip.Color(r, g, b);
+}
+
+void NeopixelRgbMultiSwissAe66::begin() {
+    _strip.begin();
+}
+
+void NeopixelRgbMultiSwissAe66::on() {
+    // Swiss Ae 6/6 tail lights: only the two outer lights are red.
+    // Assuming a 3-pixel setup (or more), where the outer-most are used.
+    if (_numPixels >= 2) {
+        _strip.setPixelColor(0, _color); // First pixel
+        _strip.setPixelColor(_numPixels - 1, _color); // Last pixel
+    }
+    // Ensure all other pixels are off
+    for (uint16_t i = 1; i < _numPixels - 1; i++) {
+        _strip.setPixelColor(i, 0);
+    }
+    _strip.show();
+}
+
+void NeopixelRgbMultiSwissAe66::off() {
+    for (uint16_t i = 0; i < _numPixels; i++) {
+        _strip.setPixelColor(i, 0);
+    }
+    _strip.show();
+}
+
+void NeopixelRgbMultiSwissAe66::setLevel(uint8_t level) {
+    _strip.setBrightness(level);
+    _strip.show();
+}
+
+void NeopixelRgbMultiSwissAe66::update(uint32_t delta_ms) {
+    // No-op
+}
+
+}

--- a/src/LightSources/NeopixelRgbMultiSwissAe66.h
+++ b/src/LightSources/NeopixelRgbMultiSwissAe66.h
@@ -1,0 +1,28 @@
+#ifndef NEOPIXELRGBMULTISWISSAE66_H
+#define NEOPIXELRGBMULTISWISSAE66_H
+
+#include "LightSource.h"
+#include <Adafruit_NeoPixel.h>
+#include <vector>
+
+namespace xDuinoRails {
+
+class NeopixelRgbMultiSwissAe66 : public LightSource {
+public:
+    NeopixelRgbMultiSwissAe66(uint8_t pin, uint16_t numPixels, uint8_t r, uint8_t g, uint8_t b);
+
+    void begin() override;
+    void on() override;
+    void off() override;
+    void setLevel(uint8_t level) override;
+    void update(uint32_t delta_ms) override;
+
+private:
+    Adafruit_NeoPixel _strip;
+    uint32_t _color;
+    uint16_t _numPixels;
+};
+
+}
+
+#endif // NEOPIXELRGBMULTISWISSAE66_H


### PR DESCRIPTION
Introduces the 'NeopixelRgbMultiSwissAe66' class to correctly model the tail light behavior of the Swiss Ae 6/6 locomotive, where only the two outer red lights are active.

The 'ae6-6-neopixel.ino' example has been updated to use this new class, fixing the issue where all three rear lights were incorrectly illuminated.