### PR TITLE
Implement TriggerSource::LOGICAL_FUNC_STATE support

### DIFF
--- a/src/FunctionMapping.cpp
+++ b/src/FunctionMapping.cpp
@@ -1,5 +1,5 @@
 #include "FunctionMapping.h"
-#include "AuxController.h"
+#include "xDuinoRails_DccLightsAndFunctions.h"
 
 namespace xDuinoRails {
 
@@ -18,6 +18,12 @@ bool ConditionVariable::evaluate(const AuxController& controller) const {
                 break;
             case TriggerSource::BINARY_STATE:
                 if (cond.comparator == TriggerComparator::IS_TRUE) result = controller.getBinaryState(cond.parameter);
+                break;
+            case TriggerSource::LOGICAL_FUNC_STATE:
+                if (cond.comparator == TriggerComparator::IS_TRUE) {
+                    const LogicalFunction* lf = controller.getLogicalFunction(cond.parameter);
+                    result = (lf != nullptr && lf->isActive());
+                }
                 break;
             default: break;
         }

--- a/src/xDuinoRails_DccLightsAndFunctions.cpp
+++ b/src/xDuinoRails_DccLightsAndFunctions.cpp
@@ -34,8 +34,8 @@ void AuxController::addLightSource(std::unique_ptr<LightSource> lightSource) {
 
 void AuxController::update(uint32_t delta_ms) {
     if (_state_changed) {
-        evaluateMapping();
         _state_changed = false;
+        evaluateMapping();
     }
     for (auto& func : _logical_functions) {
         func->update(delta_ms);
@@ -126,6 +126,10 @@ LogicalFunction* AuxController::getLogicalFunction(size_t index) {
     return (index < _logical_functions.size()) ? _logical_functions[index] : nullptr;
 }
 
+const LogicalFunction* AuxController::getLogicalFunction(size_t index) const {
+    return (index < _logical_functions.size()) ? _logical_functions[index] : nullptr;
+}
+
 void AuxController::addLogicalFunction(LogicalFunction* function) {
     _logical_functions.push_back(function);
 }
@@ -160,11 +164,15 @@ void AuxController::evaluateMapping() {
         if (rule.evaluate(*this)) {
             if (rule.target_logical_function_id < _logical_functions.size()) {
                 LogicalFunction* target_func = _logical_functions[rule.target_logical_function_id];
+                bool was_active = target_func->isActive();
                 switch (rule.action) {
                     case MappingAction::ACTIVATE: target_func->setActive(true); break;
                     case MappingAction::DEACTIVATE: target_func->setActive(false); break;
                     case MappingAction::SET_DIMMED: target_func->setDimmed(!target_func->isDimmed()); break;
                     default: break;
+                }
+                if (target_func->isActive() != was_active) {
+                    _state_changed = true;
                 }
             }
         }

--- a/src/xDuinoRails_DccLightsAndFunctions.h
+++ b/src/xDuinoRails_DccLightsAndFunctions.h
@@ -121,6 +121,13 @@ public:
      */
     LogicalFunction* getLogicalFunction(size_t index);
 
+    /**
+     * @brief Gets a const pointer to a logical function by its index.
+     * @param index The index of the logical function.
+     * @return A const pointer to the LogicalFunction, or nullptr if not found.
+     */
+    const LogicalFunction* getLogicalFunction(size_t index) const;
+
 #ifdef UNIT_TEST
 public:
 #endif


### PR DESCRIPTION
- Added handling for LOGICAL_FUNC_STATE in ConditionVariable::evaluate in FunctionMapping.cpp.
- Added const overload for getLogicalFunction in AuxController to support read-only access during evaluation.
- Fixed include in FunctionMapping.cpp to point to xDuinoRails_DccLightsAndFunctions.h instead of non-existent AuxController.h.
- Updated AuxController::evaluateMapping to set _state_changed flag when a LogicalFunction state changes, enabling cascading logic updates.
- Modified AuxController::update to reset _state_changed before evaluation to correctly capture changes during evaluation for the next cycle.